### PR TITLE
Improves Steam User Plus badgeList function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .env
 cache.json
 npm-debug.log
+temp.*

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ User.on('webLogOnResponse',function(){
     User.emit('debug',"Web Logged, calling badge list");
 
     User.badgeList({},function(list){
-        User.emit('debug','The list of badges was successfully retrieved, '+list.length+' games to idle.');
+        User.emit('debug','The list of badges was successfully retrieved, '+list.length+' games in the list.');
         User.emit('debug','Starting Idle process');
         startIdle(list,{
             restart_after: config.idle.recache_time_mnts // minutes
@@ -71,7 +71,13 @@ User.on('webLogOnResponse',function(){
     });
 });
 
-function startIdle(gamesToIdle, args){
+function startIdle(gamesList, args){
+    var gamesToIdle = []
+    gamesList.forEach(function(val){
+        if (val.remaining_drops > 0)
+            gamesToIdle.push(val);
+    });
+    User.emit('debug',gamesToIdle.length+' games to idle.');
     if (args){
         if (args.restart_after && args.restart_after >= 5){
             User.emit('debug','Setting up restart strategy');

--- a/lib/steam-user-plus.js
+++ b/lib/steam-user-plus.js
@@ -56,29 +56,29 @@ SteamUserPlus.prototype.badgeList = function(args,cb){
         }
         self.emit('debug','Badge list downloaded successfully');
         var $ = Cheerio.load(body);
-        for (var i = 0;i<$('.badge_title_row').get().length;i++){
-            var game_info = $('.badge_title_row').get(i);
-            if ($('.badge_title_playgame', game_info).html()){
-                var raw_progress = $('.progress_info_bold', game_info).html()
-                var remaining_drops = raw_progress.split(' ')[0];
-        
-                var raw_title = $('.badge_title', game_info).text();
-                var game_title = raw_title.replace("View details","").trim();
-        
-                var play_button = $('.btn_green_white_innerfade.btn_small_thin',game_info);
-                var play_button_href = play_button.attr('href');
-                var game_id = play_button_href.match(/steam:\/\/run\/(\d+)/)[1];
+        var badge_games = $('.badge_title_row').get(); 
+        for (var i = 0 ; i < badge_games.length ; i++){
+            var game_info = badge_games[i];
+            var raw_progress = $('.progress_info_bold', game_info).html()
+            if (!raw_progress) continue;
+            var remaining_drops = raw_progress.split(' ')[0];
+            if (remaining_drops == 'No') remaining_drops = 0;
+    
+            var raw_title = $('.badge_title', game_info).text();
+            var game_title = raw_title.replace("View details","").trim();
+    
+            var info_dialog_id = $('.card_drop_info_dialog', game_info).attr('id');
+            var game_id = info_dialog_id.replace('card_drop_info_gamebadge_','').split('_')[0];
 
-                var raw_hours_played = $('.badge_title_stats_playtime',game_info).text();
-                var hours_played = raw_hours_played.split(" ")[0].trim() || '0';
+            var raw_hours_played = $('.badge_title_stats_playtime',game_info).text();
+            var hours_played = raw_hours_played.split(" ")[0].trim() || '0';
 
-                returnList.push({
-                    game_title: game_title,
-                    game_id: game_id,
-                    remaining_drops: parseInt(remaining_drops),
-                    hours_played: parseFloat(hours_played)
-                });
-            }
+            returnList.push({
+                game_title: game_title,
+                game_id: game_id,
+                remaining_drops: parseInt(remaining_drops),
+                hours_played: parseFloat(hours_played)
+            });
         }
         self.emit('debug','Badge list parsed successfully');
         updateCache(self, returnList);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-steam-card-farm",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A node.js application that can farm steam cards for you. Not only that, but it also comes with a configured docker build, which you can use to deploy anywhere in the cloud.",
   "repository": "https://github.com/gabrieldrs/node-steam-card-farm",
   "main": "index.js",


### PR DESCRIPTION
At my first implementation, badgeList was only collecting information related to games that still had card drops.
Thinking about it later, I found out that it didn't make sense, and deciding to work with a subset of the badgelist should be something to be handled by the function caller.
This commit updates the badgeList function so it now retrieves the entire list of games, it also updates the main index script so it filters the list before idling, so it works only with the ones that still have card drops.
As a side note, foil badges in the badge list are skipped, because they don't have "time_played" information, I'm still unsure if I should skip these, but it will stay this way for now.

I'm also using this commit to add some temp files that I create for testing to the .gitignore.

Signed-off-by: gabrieldrs <gabriel@sezefredo.com.br>