### PR TITLE
Adds support to email token authentication

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const config = JSON.parse(fs.readFileSync('./config.json'));
 const Steam = require('steam');
 const SteamUserPlus = require('./lib/steam-user-plus');
 const Client = new Steam.SteamClient();
+const EResult = Steam.EResult;
 const User = new SteamUserPlus(Client);
 var logOnDetails = {account_name:'', password:''}
 const Idler = require('./lib/idler');
@@ -44,8 +45,14 @@ app.post('/', (req, res) => {
         logOnDetails.account_name = req.body.user;
         logOnDetails.password = req.body.password;
         delete logOnDetails.two_factor_code
-        if (req.body.token)
-            logOnDetails.two_factor_code = req.body.token;
+        if (req.body.token){
+            if (User.loginType){
+                if (User.loginType == 'two_factor')
+                    logOnDetails.two_factor_code = req.body.token;
+                else if (User.loginType == 'email')
+                    logOnDetails.auth_code = req.body.token;
+            }
+        }
         if (Client._connection){
             stopIdle();
             Client.disconnect();

--- a/lib/steam-user-plus.js
+++ b/lib/steam-user-plus.js
@@ -14,6 +14,7 @@ const Cheerio = require('cheerio');
 
 function SteamUserPlus(steamClient) {
     SteamUserPlus.super_.call(this,steamClient);
+    this.loginFailReason=null;
 }
 util.inherits(SteamUserPlus, SteamUser);
 
@@ -130,16 +131,26 @@ function updateCache(user, list){
 
 
 function authenticationError(self,response){
+    console.log(response);
     if (response.eresult == EResult.OK) return false;
     switch (response.eresult) {
         case EResult.AccountLoginDeniedNeedTwoFactor:
             self.emit('error',"Missing two factor auth code");
+            self.loginType = "two_factor";
             break;
         case EResult.TwoFactorCodeMismatch:
             self.emit('error',"Two factor auth code wrong")
+            self.loginType = "two_factor";
             break;
         case EResult.InvalidPassword:
-            self.emit('error',"Invalid Password")
+            self.emit('error',"Invalid Password or Token")
+            break;
+        case EResult.AccountLogonDenied:
+            self.emit ('error','Email token generated')
+            self.loginType = "email";
+            break;
+        case EResult.InvalidLoginAuthCode:
+            self.emit ('error','Email token invalid')
             break;
         default:
             self.emit('error',"Unknown Error")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-steam-card-farm",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "A node.js application that can farm steam cards for you. Not only that, but it also comes with a configured docker build, which you can use to deploy anywhere in the cloud.",
   "repository": "https://github.com/gabrieldrs/node-steam-card-farm",
   "main": "index.js",


### PR DESCRIPTION
When a user in steam has not configred two factor authentication in their mobile phone, steam uses their email to send the confirmation token.
In this case, the confirmation token has to be sent to steam in another json field during the logon step.
This commit identifies the type of error that occurs in a non successful logon attempt, and use that to decide if it will send the token as a two-factor authentication or an email-code authentication.

This solves bug reported at #6

Signed-off-by: Gabriel R. Sezefredo <gabriel@sezefredo.com.br>